### PR TITLE
Plugins for auto-updating

### DIFF
--- a/docs/wirelesstags/0.5.2/tutorial-read-sensors.js.html
+++ b/docs/wirelesstags/0.5.2/tutorial-read-sensors.js.html
@@ -64,7 +64,7 @@ invisible.</p>
 <pre class="prettyprint source lang-js"><code>platform.on('connect', () => {
     console.log(&quot;connected to Wireless Tag cloud&quot;);
     platform.discoverTagManagers().catch(
-        (err) => { console.error(e.stack ? e.stack : e); });
+        (err) => { console.error(err.stack ? err.stack : err); });
 });</code></pre><p>The <code>discover</code> handler for the platform will receive tag a manager
 object on each event.</p>
 <pre class="prettyprint source"><code>platform.on('discover', (manager) => {

--- a/examples/auto-update-polling.js
+++ b/examples/auto-update-polling.js
@@ -1,69 +1,49 @@
-"use strict";
+'use strict';
 
-/** 
- * Simple example script that demonstrates how to use the polling
- * updater to update tag data automatically when there is an
- * update. Unlike the auto-update loop based on the update interval
- * configured for each tag, this method should capture events
- * triggered from armed sensors within a short amount of time.
- *
- * The principle flow is similar to the interval-based auto-updating
- * example: 
- *
- * 1. Connect to cloud, find tag managers.
- * 2. For each tag manager, find its associated tags.
- * 3. For each tag, find its sensors.
- * 4. Once we have all tags for a tag manager, hand them over to the
- *    TagUpdater instance for auto-updating.
- * 5. When there is new data for a tag, log useful properties for each
- *    of its sensors (here: reading, event state (such as "Too High"
- *    for temperature), and whether it is armed (meaning that events
- *    trigger alerts, such as push notification).
- * 6. Keep auto-updating for a set period of time.
- * 
- * The implementation here uses mostly event handlers to proceed once
- * the initial connect() succeeds. One could equally well use
- * mostly Promise-chaining (via .then()).
- *
- * Both tag and sensor objects override the .toString() method to
- * produce a compact stringified-JSON representation of their key
- * properties, so dumping this to the terminal can be informative.
- * Uncomment the corresponding lines in the code below to do so.
- */
-var Platform = require('../'),
+var Platform = require('wirelesstags'),
     platform = Platform.create(),
-    TagUpdater = require('../plugins/polling-updater');
+    TagUpdater = require('wirelesstags/plugins/polling-updater');
 
-const END_AFTER = 30 * 60 * 1000; // value is in milliseconds
+var END_AFTER = 30 * 60 * 1000; // value is in milliseconds
 
-platform.on('connect', () => {
+platform.on('connect', function () {
     console.log("connected to Wireless Tag cloud");
-    platform.discoverTagManagers().
-        catch((e) => { console.error(e.stack ? e.stack : e) });
-});
-
-let updater = new TagUpdater();
-platform.on('discover', (manager) => {
-    console.log("found manager", manager.name, manager.mac);
-    manager.on('discover', (tag) => {
-        logTag(tag);
-        tag.on('discover', (sensor) => { logSensor(sensor); });
-        tag.on('data', (tag) => { logTag(tag); tag.eachSensor(logSensor); });
-        tag.discoverSensors().
-            catch((e) => { console.error(e.stack ? e.stack : e); throw e; });
+    platform.discoverTagManagers()['catch'](function (err) {
+        console.error(err.stack ? err.stack : err);
     });
-    manager.discoverTags().
-        then((tags) => {
-            updater.addTags(tags);
-            updater.startUpdateLoop();
-            setTimeout(updater.stopUpdateLoop.bind(updater), END_AFTER);
-            return tags; // only needed if we kept chaining
-        }).
-        catch((e) => { console.error(e.stack ? e.stack : e) });
 });
 
-platform.connect(Platform.loadConfig()).
-    catch((e) => { console.error(e.stack ? e.stack : e) });
+var updater = new TagUpdater();
+
+platform.on('discover', function (manager) {
+    console.log("found manager", manager.name, manager.mac);
+
+    manager.on('discover', function (tag) {
+        logTag(tag);
+        tag.on('discover', function (sensor) {
+            logSensor(sensor);
+        });
+        tag.on('data', function (tag) {
+            logTag(tag);tag.eachSensor(logSensor);
+        });
+        tag.discoverSensors()['catch'](function (e) {
+            console.error(e.stack ? e.stack : e);throw e;
+        });
+    });
+
+    manager.discoverTags().then(function (tags) {
+        updater.addTags(tags);
+        updater.startUpdateLoop();
+        setTimeout(updater.stopUpdateLoop.bind(updater), END_AFTER);
+        return tags; // only needed if we kept chaining
+    })['catch'](function (e) {
+        console.error(e.stack ? e.stack : e);
+    });
+}); // end of platform.on()
+
+platform.connect(Platform.loadConfig())['catch'](function (e) {
+    console.error(e.stack ? e.stack : e);
+});
 
 function logTag(tag) {
     console.log("Tag", tag.name, "(slaveId=" + tag.slaveId + ")");
@@ -71,8 +51,7 @@ function logTag(tag) {
 }
 
 function logSensor(sensor) {
-    console.log("..", sensor.sensorType,
-                "of", sensor.wirelessTag.name + ":");
+    console.log("..", sensor.sensorType, "of", sensor.wirelessTag.name + ":");
     console.log("    reading:", sensor.reading);
     if (sensor.eventState !== undefined) {
         console.log("    state:", sensor.eventState);

--- a/examples/auto-update-polling.js
+++ b/examples/auto-update-polling.js
@@ -1,0 +1,82 @@
+"use strict";
+
+/** 
+ * Simple example script that demonstrates how to use the polling
+ * updater to update tag data automatically when there is an
+ * update. Unlike the auto-update loop based on the update interval
+ * configured for each tag, this method should capture events
+ * triggered from armed sensors within a short amount of time.
+ *
+ * The principle flow is similar to the interval-based auto-updating
+ * example: 
+ *
+ * 1. Connect to cloud, find tag managers.
+ * 2. For each tag manager, find its associated tags.
+ * 3. For each tag, find its sensors.
+ * 4. Once we have all tags for a tag manager, hand them over to the
+ *    TagUpdater instance for auto-updating.
+ * 5. When there is new data for a tag, log useful properties for each
+ *    of its sensors (here: reading, event state (such as "Too High"
+ *    for temperature), and whether it is armed (meaning that events
+ *    trigger alerts, such as push notification).
+ * 6. Keep auto-updating for a set period of time.
+ * 
+ * The implementation here uses mostly event handlers to proceed once
+ * the initial connect() succeeds. One could equally well use
+ * mostly Promise-chaining (via .then()).
+ *
+ * Both tag and sensor objects override the .toString() method to
+ * produce a compact stringified-JSON representation of their key
+ * properties, so dumping this to the terminal can be informative.
+ * Uncomment the corresponding lines in the code below to do so.
+ */
+var Platform = require('../'),
+    platform = Platform.create(),
+    TagUpdater = require('../plugins/polling-updater');
+
+const END_AFTER = 30 * 60 * 1000; // value is in milliseconds
+
+platform.on('connect', () => {
+    console.log("connected to Wireless Tag cloud");
+    platform.discoverTagManagers().
+        catch((e) => { console.error(e.stack ? e.stack : e) });
+});
+
+let updater = new TagUpdater();
+platform.on('discover', (manager) => {
+    console.log("found manager", manager.name, manager.mac);
+    manager.on('discover', (tag) => {
+        logTag(tag);
+        tag.on('discover', (sensor) => { logSensor(sensor); });
+        tag.on('data', (tag) => { logTag(tag); tag.eachSensor(logSensor); });
+        tag.discoverSensors().
+            catch((e) => { console.error(e.stack ? e.stack : e); throw e; });
+    });
+    manager.discoverTags().
+        then((tags) => {
+            updater.addTags(tags);
+            updater.startUpdateLoop();
+            setTimeout(updater.stopUpdateLoop.bind(updater), END_AFTER);
+            return tags; // only needed if we kept chaining
+        }).
+        catch((e) => { console.error(e.stack ? e.stack : e) });
+});
+
+platform.connect(Platform.loadConfig()).
+    catch((e) => { console.error(e.stack ? e.stack : e) });
+
+function logTag(tag) {
+    console.log("Tag", tag.name, "(slaveId=" + tag.slaveId + ")");
+    // console.log(".. properties:", tag.toString());
+}
+
+function logSensor(sensor) {
+    console.log("..", sensor.sensorType,
+                "of", sensor.wirelessTag.name + ":");
+    console.log("    reading:", sensor.reading);
+    if (sensor.eventState !== undefined) {
+        console.log("    state:", sensor.eventState);
+        console.log("    armed:", sensor.isArmed());
+    }
+    // console.log("... sensor properties:", sensor.toString());
+}

--- a/examples/auto-update-polling.js
+++ b/examples/auto-update-polling.js
@@ -1,8 +1,9 @@
 'use strict';
 
 var Platform = require('wirelesstags'),
-    platform = Platform.create(),
-    TagUpdater = require('wirelesstags/plugins/polling-updater');
+    platform = Platform.create();
+
+var TagUpdater = require('wirelesstags/plugins/polling-updater');
 
 var END_AFTER = 30 * 60 * 1000; // value is in milliseconds
 

--- a/examples/auto-update-polling.js.md
+++ b/examples/auto-update-polling.js.md
@@ -1,0 +1,127 @@
+## Using polling to auto-update sensor data
+
+Simple example script that demonstrates how to use the polling updater
+to update tag data automatically when there is an update. Unlike the
+auto-update loop based on the update interval configured for each tag
+(see {@tutorial read-sensors.js}), this method should capture events
+triggered by armed sensors within a short amount of time.
+
+The code in this tutorial is also available as a JavaScript file
+(generated automatically from this tutorial) that can be run with
+`nodejs`. See the [`examples/`] directory of the package.
+
+### Principle flow
+
+The principle flow is taken straight from {@tutorial read-sensors.js}:
+
+1. Connect to cloud.
+2. Find [tag managers]{@link WirelessTagManager}.
+3. For each tag manager, find its associated [tags]{@link WirelessTag}.
+4. For each tag, find its [sensors]{@link WirelessTagSensor}.
+5. Hand sensors over to the TagUpdater instance for auto-updating.
+6. When there is new data for a tag, do something useful with the
+   data. Here we simply log useful properties for each sensor and tag
+   (see {@tutorial read-sensors.js}).
+7. Continue updating for a set period of time.
+
+### Create platform object
+
+    var Platform = require('wirelesstags'),
+        platform = Platform.create(),
+        TagUpdater = require('wirelesstags/plugins/polling-updater');
+
+How long to keep looping?
+
+    const END_AFTER = 30 * 60 * 1000; // value is in milliseconds
+
+### Set up event handlers
+
+In this implementation here we use mostly event handlers to proceed
+once the initial [connect()]{@link WirelessTagPlatform#connect}
+succeeds. One could equally well use `Promise`-chaining (via
+`.then()`). Note that if we do not use callbacks, it is a good idea to
+`.catch()` rejected promises, because otherwise errors thrown will be
+invisible.
+
+In the `connect` event handler, trigger discovery of tag managers (see
+[discoverTagManagers()]{@link WirelessTagPlatform#discoverTagManagers}):
+
+
+    platform.on('connect', () => {
+        console.log("connected to Wireless Tag cloud");
+        platform.discoverTagManagers().catch(
+            (err) => { console.error(err.stack ? err.stack : err);
+        });
+    });
+
+Create the updater instance:
+
+    let updater = new TagUpdater();
+
+The `discover` handler for the platform will receive tag a manager
+object on each event.
+
+    platform.on('discover', (manager) => {
+        console.log("found manager", manager.name, manager.mac);
+
+Next, we install an event handlers for the tag manager's `discover`
+event, which will be fired for each associated tag. For each
+discovered tag, install event handlers for `discover` (fired for each
+of their sensors) and `data` events (fired each time its data is
+updated). This is the same sequence as in {@tutorial read-sensors.js}.
+Once event handlers for the tag are installed, ask the tag to find its
+sensors.
+
+        manager.on('discover', (tag) => {
+            logTag(tag);
+            tag.on('discover', (sensor) => { logSensor(sensor); });
+            tag.on('data', (tag) => { logTag(tag); tag.eachSensor(logSensor); });
+            tag.discoverSensors().
+                catch((e) => { console.error(e.stack ? e.stack : e); throw e; });
+        });
+
+Now ask the tag manager to find associated tags (which will trigger
+the tag `discover` events and above handler). When done, register all
+tags with the update instance, and start polling for updates.
+
+        manager.discoverTags().
+            then((tags) => {
+                updater.addTags(tags);
+                updater.startUpdateLoop();
+                setTimeout(updater.stopUpdateLoop.bind(updater), END_AFTER);
+                return tags; // only needed if we kept chaining
+            }).
+            catch((e) => { console.error(e.stack ? e.stack : e) });
+    }); // end of platform.on()
+
+### Connect to platform
+
+Once the event handlers are set up, connect to the platform. This is
+the same as in {@tutorial read-sensors.js}.
+
+    platform.connect(Platform.loadConfig()).
+        catch((e) => { console.error(e.stack ? e.stack : e) });
+
+### Do something with tags and sensors
+
+The actions for tags and sensors here are simply copied from {@tutorial read-sensors.js}.
+
+```js
+function logTag(tag) {
+    console.log("Tag", tag.name, "(slaveId=" + tag.slaveId + ")");
+    // console.log(".. properties:", tag.toString());
+}
+
+function logSensor(sensor) {
+    console.log("..", sensor.sensorType,
+                "of", sensor.wirelessTag.name + ":");
+    console.log("    reading:", sensor.reading);
+    if (sensor.eventState !== undefined) {
+        console.log("    state:", sensor.eventState);
+        console.log("    armed:", sensor.isArmed());
+    }
+    // console.log("... sensor properties:", sensor.toString());
+}
+```
+
+[`examples/`]: https://github.com/hlapp/wirelesstags-js/tree/master/examples

--- a/examples/auto-update-polling.js.md
+++ b/examples/auto-update-polling.js.md
@@ -27,12 +27,14 @@ The principle flow is taken straight from {@tutorial read-sensors.js}:
 ### Create platform object
 
     var Platform = require('wirelesstags'),
-        platform = Platform.create(),
-        TagUpdater = require('wirelesstags/plugins/polling-updater');
+        platform = Platform.create();
 
-How long to keep looping?
+### Create tag updater
 
-    const END_AFTER = 30 * 60 * 1000; // value is in milliseconds
+Here we determine which tag updater we use. Here we want to use the
+one that uses polling.
+
+    var TagUpdater = require('wirelesstags/plugins/polling-updater');
 
 ### Set up event handlers
 
@@ -42,6 +44,10 @@ succeeds. One could equally well use `Promise`-chaining (via
 `.then()`). Note that if we do not use callbacks, it is a good idea to
 `.catch()` rejected promises, because otherwise errors thrown will be
 invisible.
+
+How long to keep looping?
+
+    const END_AFTER = 30 * 60 * 1000; // value is in milliseconds
 
 In the `connect` event handler, trigger discovery of tag managers (see
 [discoverTagManagers()]{@link WirelessTagPlatform#discoverTagManagers}):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wirelesstags",
-  "version": "0.5.2",
+  "version": "0.5.3-beta.1",
   "description": "Interface to the Wireless Sensor Tags platform (http://wirelesstag.net)",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha",
     "test:ci": "npm run test -- test/{01,02,03}_*.js",
     "test:rw": "npm run test -- test/{04}_*.js",
-    "lint": "jshint index.js lib/*.js lib/error/*.js examples/*.js test/*.js",
+    "lint": "jshint index.js lib/*.js lib/error/*.js examples/*.js plugins/*.js test/*.js",
     "pretest": "npm run lint",
     "doc": "jsdoc --access all -r -c .jsdoc-conf.json -d ./docs/ .",
     "predoc": "rm -rf docs/$npm_package_name/$npm_package_version",
@@ -31,6 +31,7 @@
     "deep-equal": ">=1.0.1",
     "promise-retry": "^1.1.1",
     "request": ">=2.79.0",
+    "soap": "^0.18.0",
     "timeout-as-promise": "^1.0.0"
   },
   "devDependencies": {

--- a/plugins/interval-updater.js
+++ b/plugins/interval-updater.js
@@ -1,0 +1,93 @@
+"use strict";
+
+/** 
+ * This is a TagUpdater plugin implementation that simply uses the {@link
+ * WirelessTag#startUpdateLoop} and {@link WirelessTag#stopUpdateLoop}
+ * methods, which auto-update a tag based on the update interval
+ * configured for it.
+ *
+ * The main motivation is to have a module for using an interval-based
+ * update method that uses the same API interface as others, and can
+ * thus be swapped in.
+ *
+ * @module
+ */
+
+/**
+ * Creates the updater instance.
+ *
+ * @constructor
+ */
+function TimedTagUpdater() {
+    this.tagsByUUID = {};
+}
+
+/**
+ * Adds the given tags to the ones to be updated by this updater. If
+ * the update loop is already running (because
+ * [startUpdateLoop()]{@link module:plugins/interval-updater~TimedTagUpdater#startUpdateLoop}
+ * was called), the tag will start auto-updating.
+ *
+ * @param {(WirelessTag|WirelessTag[])} tags - the tags (or the tag) to
+ *                                           be updated
+ *
+ * @return {module:plugins/interval-updater~TimedTagUpdater}
+ */
+TimedTagUpdater.prototype.addTags = function(tags) {
+    if (!Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (this._running) tag.startUpdateLoop();
+        this.tagsByUUID[tag.uuid] = tag;
+    }
+    return this;
+};
+
+/**
+ * Removes the given tags from the ones to be updated by this
+ * updater. If the update loop is already running (because
+ * [startUpdateLoop()]{@link module:plugins/interval-updater~TimedTagUpdater#startUpdateLoop}
+ * was called), the tag will stop auto-updating.
+ *
+ * @param {(WirelessTag|WirelessTag[])} tags - the tags (or the tag) to
+ *                                           be removed from updating
+ *
+ * @return {module:plugins/interval-updater~TimedTagUpdater}
+ */
+TimedTagUpdater.prototype.removeTags = function(tags) {
+    if (tags && !Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (this._running) tag.stopUpdateLoop();
+        delete this.tagsByUUID[tag.uuid];
+    }
+    return this;
+};
+
+/**
+ * Starts the continuous update loop. Registered tags will get updated
+ * until they are removed, or [stopUpdateLoop()]{@link module:plugins/interval-updater~TimedTagUpdater#stopUpdateLoop}
+ * is called.
+ */
+TimedTagUpdater.prototype.startUpdateLoop = function() {
+    if (this._running) return this;
+    this._running = true;
+    for (let uuid in this.tagsByUUID) {
+        this.tagsByUUID[uuid].startUpdateLoop();
+    }
+    return this;
+};
+
+/**
+ * Stops the continuous update loop. Has no effect if an update loop
+ * is not currently active.
+ */
+TimedTagUpdater.prototype.stopUpdateLoop = function() {
+    if (this._running) {
+        this._running = false;
+        for (let uuid in this.tagsByUUID) {
+            this.tagsByUUID[uuid].stopUpdateLoop();
+        }
+    }
+    return this;
+};
+
+module.exports = TimedTagUpdater;

--- a/plugins/polling-updater.js
+++ b/plugins/polling-updater.js
@@ -5,7 +5,8 @@ var request = require('request'),
 
 const WSDL_URL_PATH = "/ethComet.asmx?WSDL";
 const API_BASE_URI = "https://www.mytaglist.com";
-const UPDATE_LOOP_WAIT = 1000;
+const UPDATE_LOOP_WAIT = 20;
+const WAIT_AFTER_ERROR = 1000;
 
 function PollingTagUpdater(platform, config) {
     this.tagsByUUID = {};
@@ -51,7 +52,8 @@ PollingTagUpdater.prototype.startUpdateLoop = function(waitTime) {
             waitTime = undefined;
         }).catch((err) => {
             console.error(err.stack ? err.stack : err);
-            waitTime = waitTime * 2;
+            waitTime = waitTime < WAIT_AFTER_ERROR ?
+                WAIT_AFTER_ERROR : waitTime * 2;
         }).then(() => {
             // with the preceding catch() this is in essence a finally()
             if (this._updateTimer) {

--- a/plugins/polling-updater.js
+++ b/plugins/polling-updater.js
@@ -1,0 +1,129 @@
+"use strict";
+
+var request = require('request'),
+    soap = require('soap');
+
+const WSDL_URL = "https://www.mytaglist.com/ethComet.asmx?WSDL";
+const UPDATE_LOOP_WAIT = 1000;
+
+function PollingTagUpdater() {
+    this.tagsByUUID = {};
+}
+
+PollingTagUpdater.prototype.addTags = function(tags) {
+    if (tags && !Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        this.tagsByUUID[tag.uuid] = tag;
+    }
+    return this;
+};
+
+PollingTagUpdater.prototype.removeTags = function(tags) {
+    if (tags && !Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        delete this.tagsByUUID[tag.uuid];
+    }
+    return this;
+};
+
+PollingTagUpdater.prototype.startUpdateLoop = function(waitTime) {
+    if (waitTime === undefined) waitTime = UPDATE_LOOP_WAIT;
+    if (this._updateTimer) return this._updateTimer;
+    this._updateTimer = true; // placeholder to avoid race conditions
+    let action = () => {
+        this._updateTimer = true; // timer is done but action not yet
+        this.apiClient().then((client) => {
+            return pollForNextUpdate(client);
+        }).then((tagDataList) => {
+            tagDataList.forEach((tagData) => {
+                this.updateTagFrom(tagData);
+            });
+            // reset wait time upon success
+            waitTime = undefined;
+        }).catch((err) => {
+            console.error(err.stack ? err.stack : err);
+            waitTime = waitTime * 2;
+        }).then(() => {
+            // with the preceding catch() this is in essence a finally()
+            if (this._updateTimer) {
+                this._updateTimer = null;
+                this.startUpdateLoop(waitTime);
+            }
+            // otherwise we have been cancelled while running the update
+        });
+    };
+    // ensure that updates weren't cancelled since we entered here
+    if (this._updateTimer === true) {
+        this._updateTimer = setTimeout(action, waitTime);
+    }
+    return this._updateTimer;
+};
+
+PollingTagUpdater.prototype.stopUpdateLoop = function() {
+    let timer = this._updateTimer;
+    this._updateTimer = null;   // avoid race conditions
+    if (timer && timer !== true) {
+        clearTimeout(timer);
+    }
+};
+
+PollingTagUpdater.prototype.bounceUpdateLoop = function() {
+    return this;
+};
+
+PollingTagUpdater.prototype.updateTagFrom = function(tagData) {
+    // identify tag
+    let tag = this.tagsByUUID[tagData.uuid];
+    // if not listed for receiving updates, we are done
+    if (! tag) return;
+    // check that this is the current tag manager
+    if (tagData.mac && (tag.wirelessTagManager.mac !== tagData.mac)) {
+        throw new Error("expected tag " + tag.uuid
+                        + " to be with tag manager " + tag.mac
+                        + " but is reported to be with " + tagData.mac);
+    }
+    // we don't currently have anything more to do for the extra properties
+    // identifying the tag manager, so simply get rid of them
+    ['managerName','mac','dbid','mirrors'].forEach((k) => {
+        delete tagData[k];
+    });
+    // almost done
+    tag.data = tagData;
+};
+
+PollingTagUpdater.prototype.apiClient = function() {
+    if (this.client) return Promise.resolve(this.client);
+    return createSoapClient(this.options).then((client) => {
+        this.client = client;
+        return client;
+    });
+};
+
+function createSoapClient(opts) {
+    let wsdl = opts && opts.wsdl ? opts.wsdl : WSDL_URL;
+    let clientOpts = { request: request.defaults({ jar: true, gzip: true }) };
+    return new Promise((resolve, reject) => {
+        soap.createClient(wsdl, clientOpts, (err, client) => {
+            if (err) return reject(err);
+            resolve(client);
+        });
+    }); 
+}
+
+function pollForNextUpdate(client, tagManager) {
+    return new Promise((resolve, reject) => {
+        let methodName = tagManager ?
+            "GetNextUpdateForAllManagersOnDB" :
+            "GetNextUpdateForAllManagers";
+        let soapMethod = client[methodName];
+        let args = {};
+        if (tagManager) args.dbid = tagManager.dbid;
+        soapMethod(args, function(err, result) {
+            if (err) return reject(err);
+            let tagDataList = JSON.parse(result[methodName + "Result"]);
+            resolve(tagDataList);
+        });
+    });
+}
+
+module.exports = PollingTagUpdater;

--- a/plugins/polling-updater.js
+++ b/plugins/polling-updater.js
@@ -43,13 +43,19 @@ const API_BASE_URI = "https://www.mytaglist.com";
  *                   polling endpoint (in milliseconds)
  * @default
  */
-const UPDATE_LOOP_WAIT = 20;
+const UPDATE_LOOP_WAIT = 10;
 /**
  * @const {number} - the minimum time to wait between subsequent calls of the
  *                   polling endpoint after an error occurred (in milliseconds)
  * @default
  */
 const WAIT_AFTER_ERROR = 1000;
+/**
+ * @const {number} - the maximum time to wait between subsequent calls of the
+ *                   polling endpoint (in milliseconds)
+ * @default
+ */
+const MAX_UPDATE_LOOP_WAIT = 30 * 60 * 1000;
 
 /**
  * Creates the updater instance.
@@ -127,8 +133,11 @@ PollingTagUpdater.prototype.removeTags = function(tags) {
  */
 PollingTagUpdater.prototype.startUpdateLoop = function(waitTime) {
     if (waitTime === undefined) waitTime = UPDATE_LOOP_WAIT;
+    if (waitTime > MAX_UPDATE_LOOP_WAIT) waitTime = MAX_UPDATE_LOOP_WAIT;
+
     if (this._updateTimer) return this._updateTimer;
     this._updateTimer = true; // placeholder to avoid race conditions
+
     let action = () => {
         this._updateTimer = true; // timer is done but action not yet
         this.apiClient().then((client) => {

--- a/plugins/polling-updater.js
+++ b/plugins/polling-updater.js
@@ -1,13 +1,77 @@
 "use strict";
 
+/**
+ * Uses a SOAP endpoint in the cloud API to continuously poll for
+ * available updates.
+ *
+ * The SOAP endpoint (`/ethComet.asmx`) is undocumented, but is the
+ * one used by the [client web application](http://wirelesstag.net/media/mytaglist.com/apidoc.html).
+ * The difference is that this implementation uses a proper SOAP API
+ * interface (in contrast to hand-building the XML to be transmitted,
+ * and to parsing the returned XML with a regex), and that it calls a
+ * different method at that endpoint.
+ *
+ * This updater should receive updates resulting from armed sensors
+ * going below or above their configured thresholds, or detecting
+ * motion. The one caveat is that there is a short wait time (see
+ * [UPDATE_LOOP_WAIT]{@link module:plugins/polling-updater~UPDATE_LOOP_WAIT}),
+ * and an exponentially increasing wait time after errors (see
+ * [WAIT_AFTER_ERROR]{@link module:plugins/polling-updater~WAIT_AFTER_ERROR})
+ * until the next poll is issued. Updates falling into this time
+ * period will only be caught at the next regular update interval
+ * configured for a tag.
+ *
+ * @module
+ */
+
 var request = require('request'),
     soap = require('soap');
 
+/**
+ * @const {string} - the path (relative to `API_BASE_URI`) of the WSDL
+ *                   endpoint description for polling
+ * @default
+ */
 const WSDL_URL_PATH = "/ethComet.asmx?WSDL";
+/**
+ * @const {string} - the base URI of the polling API endpoint
+ * @default
+ */
 const API_BASE_URI = "https://www.mytaglist.com";
+/**
+ * @const {number} - the time to wait between subsequent calls of the
+ *                   polling endpoint (in milliseconds)
+ * @default
+ */
 const UPDATE_LOOP_WAIT = 20;
+/**
+ * @const {number} - the minimum time to wait between subsequent calls of the
+ *                   polling endpoint after an error occurred (in milliseconds)
+ * @default
+ */
 const WAIT_AFTER_ERROR = 1000;
 
+/**
+ * Creates the updater instance.
+ *
+ * @param {WirelessTagPlatform} [platform] - Platform object through
+ *                              which tags to be updated were (or are
+ *                              going to be) found. Used solely for
+ *                              possibly overriding configuration
+ *                              options, specifically the base URI for
+ *                              the cloud API endpoints.
+ * @param {object} [config] - overriding configuration options
+ * @param {string} [config.wsdl_url] - the full path for obtaining the
+ *                              WSDL for the SOAP service to be polled
+ *                              (default: [WSDL_URL_PATH]{@link
+ *                              module:plugins/polling-updater~WSDL_URL_PATH})
+ * @param {string} [config.apiBaseURI] - the base URI to use for API
+ *                              endpoints (default:
+ *                              [API_BASE_URI]{@link
+ *                              module:plugins/polling-updater~API_BASE_URI})
+ *
+ * @constructor
+ */
 function PollingTagUpdater(platform, config) {
     this.tagsByUUID = {};
     this.options = Object.assign({}, config);
@@ -20,6 +84,14 @@ function PollingTagUpdater(platform, config) {
     }
 }
 
+/**
+ * Adds the given tags to the ones to be updated by this updater.
+ *
+ * @param {(WirelessTag|WirelessTag[])} tags - the tags (or the tag) to
+ *                                           be updated
+ *
+ * @return {module:plugins/polling-updater~PollingTagUpdater}
+ */
 PollingTagUpdater.prototype.addTags = function(tags) {
     if (!Array.isArray(tags)) tags = [tags];
     for (let tag of tags) {
@@ -28,6 +100,14 @@ PollingTagUpdater.prototype.addTags = function(tags) {
     return this;
 };
 
+/**
+ * Removes the given tags from the ones to be updated by this updater.
+ *
+ * @param {(WirelessTag|WirelessTag[])} tags - the tags (or the tag) to
+ *                                           be removed from updating
+ *
+ * @return {module:plugins/polling-updater~PollingTagUpdater}
+ */
 PollingTagUpdater.prototype.removeTags = function(tags) {
     if (tags && !Array.isArray(tags)) tags = [tags];
     for (let tag of tags) {
@@ -36,6 +116,15 @@ PollingTagUpdater.prototype.removeTags = function(tags) {
     return this;
 };
 
+/**
+ * Starts the continuous update loop. Registered tags will get updated
+ * until they are removed, or [stopUpdateLoop()]{@link module:plugins/polling-updater~PollingTagUpdater#stopUpdateLoop}
+ * is called.
+ *
+ * @param {number} [waitTime] - the time to wait until scheduling the
+ *                 next update; defaults to [UPDATE_LOOP_WAIT]{@link
+ *                 module:plugins/polling-updater~UPDATE_LOOP_WAIT}.
+ */
 PollingTagUpdater.prototype.startUpdateLoop = function(waitTime) {
     if (waitTime === undefined) waitTime = UPDATE_LOOP_WAIT;
     if (this._updateTimer) return this._updateTimer;
@@ -70,6 +159,10 @@ PollingTagUpdater.prototype.startUpdateLoop = function(waitTime) {
     return this._updateTimer;
 };
 
+/**
+ * Stops the continuous update loop. Has no effect if an update loop
+ * is not currently active.
+ */
 PollingTagUpdater.prototype.stopUpdateLoop = function() {
     let timer = this._updateTimer;
     this._updateTimer = null;   // avoid race conditions
@@ -78,6 +171,12 @@ PollingTagUpdater.prototype.stopUpdateLoop = function() {
     }
 };
 
+/**
+ * If necessary creates, and otherwise obtains from cache the SOAP
+ * client instance for the WSDL endpoint.
+ *
+ * @returns {Promise} Resolves to the SOAP client object.
+ */
 PollingTagUpdater.prototype.apiClient = function() {
     if (this.client) return Promise.resolve(this.client);
     return createSoapClient(this.options).then((client) => {
@@ -86,6 +185,14 @@ PollingTagUpdater.prototype.apiClient = function() {
     });
 };
 
+/**
+ * Updates the tag corresponding to the given tag data. Does nothing
+ * if the respective tag is undefined or null.
+ *
+ * @param {WirelessTag} tag - the tag object to be updated
+ * @param {object} tagData - the data to update the tag object with;
+ *                 this is normally returned from the API endpoint
+ */
 function updateTag(tag, tagData) {
     // if not a valid object for receiving updates, we are done
     if (! tag) return;
@@ -104,7 +211,20 @@ function updateTag(tag, tagData) {
     tag.data = tagData;
 }
 
-
+/**
+ * Creates the SOAP client, using the supplied options for locating
+ * the WSDL document for the endpoint.
+ *
+ * @param {object} [opts] - WSDL and SOAP endpoint options
+ * @param {string} [opts.wsdl_url] - the URL from which to fetch the
+ *                 WSDL document; defaults to the concatenation of
+ *                 [API_BASE_URI]{@link
+ *                 module:plugins/polling-updater~API_BASE_URI} and
+ *                 [WSDL_URL_PATH]{@link
+ *                 module:plugins/polling-updater~WSDL_URL_PATH}
+ *
+ * @returns {Promise} On success, resolves to the created SOAP client object
+ */
 function createSoapClient(opts) {
     let wsdl = opts && opts.wsdl_url ?
         opts.wsdl_url : API_BASE_URI + WSDL_URL_PATH;
@@ -117,6 +237,15 @@ function createSoapClient(opts) {
     }); 
 }
 
+/**
+ * Polls the API endpoint for available updates and returns them.
+ *
+ * @param {object} client - the SOAP client object
+ * @param {WirelessTagManager} [tagManager] - the tag manager to which
+ *                             to restrict updates (this is currently ignored)
+ *
+ * @returns {Promise} On success, resolves to an array of tag data objects
+ */
 function pollForNextUpdate(client, tagManager) {
     return new Promise((resolve, reject) => {
         let methodName = tagManager ?

--- a/plugins/polling-updater.js
+++ b/plugins/polling-updater.js
@@ -3,11 +3,20 @@
 var request = require('request'),
     soap = require('soap');
 
-const WSDL_URL = "https://www.mytaglist.com/ethComet.asmx?WSDL";
+const WSDL_URL_PATH = "/ethComet.asmx?WSDL";
+const API_BASE_URI = "https://www.mytaglist.com";
 const UPDATE_LOOP_WAIT = 1000;
 
-function PollingTagUpdater() {
+function PollingTagUpdater(platform, config) {
     this.tagsByUUID = {};
+    this.options = Object.assign({}, config);
+    if (! this.options.wsdl_url) {
+        let apiBaseURI;
+        if (platform) apiBaseURI = platform.apiBaseURI;
+        if (config && config.apiBaseURI) apiBaseURI = config.apiBaseURI;
+        if (! apiBaseURI) apiBaseURI = API_BASE_URI;
+        this.options.wsdl_url = apiBaseURI + WSDL_URL_PATH;
+    }
 }
 
 PollingTagUpdater.prototype.addTags = function(tags) {


### PR DESCRIPTION
Adds a plugin module for using the same SOAP endpoint as the vendor-provided web application for continuously polling for updates.

Also adds a second plugin that implements the same API but delegates auto-updating to the interval-based auto-updating available through the WirelessTag class API.