### PR TITLE
Allows tag discovery in one go from platform object

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -141,7 +141,8 @@ WirelessTagPlatform.prototype.isConnected = function(callback) {
  *                 'mac'. Consult the [GetTagManagers JSON API]{@link
  *                 http://wirelesstag.net/media/mytaglist.com/ethAccount.asmx@op=GetTagManagers.html}
  *                 for possible keys.
- * @param {module:wirelesstags~apiCallback} [callback]
+ * @param {module:wirelesstags~apiCallback} [callback] - if provided,
+ *                `query` must be provided too, even if as value undefined.
  *
  * @fires WirelessTagPlatform#discover
  * @returns {Promise} resolves to an array of (optionally filtered)
@@ -183,6 +184,25 @@ WirelessTagPlatform.prototype.discoverTagManagers = function(query, callback) {
     );
 };
 
+/**
+ * Retrieves the tag manager with the given MAC identifier. If the
+ * matching object is cached from an earlier call to this or the
+ * {@link WirelessTagPlatform#discoverTagManagers} method, the cached
+ * object is returned. Otherwise the matching object, if one is
+ * available and accessible to the logged-in account, is retrieved
+ * from the cloud.
+ *
+ * Note that the [discover event]{@link WirelessTagPlatform#event:discover}
+ * is only fired if the tag manager wasn't cached yet.
+ *
+ * @param {string} mac - the MAC identifier for the tag manager
+ * @param {module:wirelesstags~apiCallback} [callback]
+ *
+ * @fires WirelessTagPlatform#discover
+ * @returns {Promise} resolves to the matching {@link WirelessTagManager}
+ *                    instance if one is accessible to the logged-in account,
+ *                    and to undefined otherwise.
+ */
 WirelessTagPlatform.prototype.findTagManager = function(mac, callback) {
     let mgr = this.getTagManager(mac);
     if (mgr) {
@@ -196,10 +216,54 @@ WirelessTagPlatform.prototype.findTagManager = function(mac, callback) {
     });
 };
 
+/**
+ * Retrieves the tag manager object with the given MAC identifier from
+ * the cache.
+ *
+ * Note that this method will _not_ consult an API endpoint if the
+ * object is not yet cached. Hence, no 'discover' event will be fired.
+ *
+ * @param {string} mac - the MAC identifier for the tag manager
+ *
+ * @returns {WirelessTagManager} the matching {@link WirelessTagManager}
+ *                    instance if one is cached, and undefined otherwise.
+ */
 WirelessTagPlatform.prototype.getTagManager = function(mac) {
     return this._tagManagersByMAC.get(mac);
 };
 
+/**
+ * Retrieves the tags available to the connected account. The list is
+ * optionally filtered depending on the supplied query parameter.
+ *
+ * This method offers an alternative discovery path compared to
+ * discovering tag manager objects first (through {@link
+ * WirelessTagPlatform#discoverTagManagers}), and then for each one
+ * finding its associated tags. In the case of multiple tag managers
+ * this method will be more efficient, because the respective Web
+ * Service API endpoints do not support filtering results server-side
+ * anyway.
+ *
+ * Note that tag manager objects newly created as a side effect will
+ * generate ['discover']{@link WirelessTagPlatform#event:discover} events,
+ * and the tag manager objects will in turn fire ['discover']{@link WirelessTagManager#event:discover}
+ * events for each of their associated tags.
+ *
+ * @param {Object} [query] - an object with keys and values that a tag
+ *                 data object returned by the API has to meet. The
+ *                 most useful ones are likely `name` and
+ *                 `uuid`. Consult the [GetTagForSlaveId JSON API]{@link http://wirelesstag.net/media/mytaglist.com/ethClient.asmx@op=GetTagForSlaveId.html}
+ *                 for possible keys. The special key `wirelessTagManager`
+ *                 can be used to add a query object for tag managers
+ *                 (see {@link WirelessTagPlatform#discoverTagManagers}).
+ * @param {module:wirelesstags~apiCallback} [callback] - if provided,
+ *                `query` must be provided too, even if as value undefined.
+ *
+ * @fires WirelessTagPlatform#discover
+ * @returns {Promise} resolves to an array of {@link WirelessTag}
+ *                    instances associated with tag managers
+ *                    accessible to the logged-in account.
+ */
 WirelessTagPlatform.prototype.discoverTags = function(query, callback) {
 
     // we will need all matching tag manager objects anyway, so request an

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -202,6 +202,7 @@ WirelessTagPlatform.prototype.discoverTagManagers = function(query, callback) {
  * @returns {Promise} resolves to the matching {@link WirelessTagManager}
  *                    instance if one is accessible to the logged-in account,
  *                    and to undefined otherwise.
+ * @since 0.6.0
  */
 WirelessTagPlatform.prototype.findTagManager = function(mac, callback) {
     let mgr = this.getTagManager(mac);
@@ -227,6 +228,7 @@ WirelessTagPlatform.prototype.findTagManager = function(mac, callback) {
  *
  * @returns {WirelessTagManager} the matching {@link WirelessTagManager}
  *                    instance if one is cached, and undefined otherwise.
+ * @since 0.6.0
  */
 WirelessTagPlatform.prototype.getTagManager = function(mac) {
     return this._tagManagersByMAC.get(mac);
@@ -263,6 +265,7 @@ WirelessTagPlatform.prototype.getTagManager = function(mac) {
  * @returns {Promise} resolves to an array of {@link WirelessTag}
  *                    instances associated with tag managers
  *                    accessible to the logged-in account.
+ * @since 0.6.0
  */
 WirelessTagPlatform.prototype.discoverTags = function(query, callback) {
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -54,6 +54,8 @@ function WirelessTagPlatform(options) {
     /** @member {function} - see {@link WirelessTagPlatform.callAPI} */
     this.callAPI = WirelessTagPlatform.callAPI;
     this._tagManagersByMAC = new Map();
+    /** @member {WirelessTagPlatform~factory} */
+    this.factory = options.factory || WirelessTagPlatform.factory(this);
 }
 util.inherits(WirelessTagPlatform, EventEmitter);
 
@@ -164,7 +166,7 @@ WirelessTagPlatform.prototype.discoverTagManagers = function(query, callback) {
                 if (tagManager) {
                     tagManager.data = mgrData;
                 } else {
-                    tagManager = new WirelessTagManager(this, mgrData);
+                    tagManager = this.factory.createTagManager(mgrData);
                     this.emit('discover', tagManager);
                 }
                 tagManagers.push(tagManager);
@@ -262,6 +264,7 @@ WirelessTagPlatform.prototype.getTagManager = function(mac) {
  *                `query` must be provided too, even if as value undefined.
  *
  * @fires WirelessTagPlatform#discover
+ * @fires WirelessTagManager#discover
  * @returns {Promise} resolves to an array of {@link WirelessTag}
  *                    instances associated with tag managers
  *                    accessible to the logged-in account.
@@ -305,7 +308,7 @@ WirelessTagPlatform.prototype.discoverTags = function(query, callback) {
                 // create and populate tag objects
                 let tagsList = rec.tags.filter(filter);
                 for (let tagData of tagsList) {
-                    let tag = new WirelessTag(mgr, tagData);
+                    let tag = this.factory.createTag(mgr, tagData);
                     // console.log(tagData);
                     tagObjs.push(tag);
                     mgr.emit('discover', tag);
@@ -362,6 +365,41 @@ WirelessTagPlatform.prototype.selectTagManager = function(tagManager,callback) {
 WirelessTagPlatform.prototype.retryOnError = function(enable) {
     if (enable !== undefined) this._retryAPICalls = enable;
     return this._retryAPICalls || false;
+};
+
+/**
+ * @typedef {Object} WirelessTagPlatform~factory
+ * @property {function} createTag - expects two parameters, the {@link
+ *              WirelessTagManager} instance with which the tag object
+ *              to be created is associated, and the tag's attributes
+ *              as an object (typically this is returned by the cloud
+ *              API)
+ * @property {function} createTagManager - expects one parameter, the
+ *              tag manager's attributes as an object (typically this
+ *              is returned by the cloud API).
+ */
+
+/**
+ * Creates and returns a factory for Wireless Tag objects,
+ * specifically tag and tag manager objects. It is the default factory.
+ *
+ * @param {WirelessTagPlatform} [platform] - the platform instance
+ *                   that will be using the factory. Can be omitted,
+ *                   but then any attempt to invoke cloud API-relying
+ *                   methods of the created objects will fail.
+ * @returns {WirelessTagPlatform~factory}
+ */
+WirelessTagPlatform.factory = function(platform) {
+    let f = {
+        createTag: (mgr, data) => {
+            if (! mgr.wirelessTagPlatform) mgr.wirelessTagPlatform = platform;
+            let tag = new WirelessTag(mgr, data);
+            if (! tag.callAPI) tag.callAPI = WirelessTagPlatform.callAPI;
+            return tag;
+        },
+        createTagManager: (data) => new WirelessTagManager(platform, data)
+    };
+    return f;
 };
 
 /**

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -10,7 +10,8 @@ var request = require('request'),
     EventEmitter = require('events');
 
 var u = require('./util'),
-    WirelessTagManager = require('./tagmanager');
+    WirelessTagManager = require('./tagmanager'),
+    WirelessTag = require('./tag');
 
 /**
  * @const {string} - The default base URI for the JSON API server.
@@ -52,6 +53,7 @@ function WirelessTagPlatform(options) {
     this.apiBaseURI = options.apiBaseURI || API_BASE_URI;
     /** @member {function} - see {@link WirelessTagPlatform.callAPI} */
     this.callAPI = WirelessTagPlatform.callAPI;
+    this._tagManagersByMAC = new Map();
 }
 util.inherits(WirelessTagPlatform, EventEmitter);
 
@@ -146,21 +148,104 @@ WirelessTagPlatform.prototype.isConnected = function(callback) {
  *                    {@link WirelessTagManager} instances
  */
 WirelessTagPlatform.prototype.discoverTagManagers = function(query, callback) {
+
     var req = this.callAPI(
         '/ethAccount.asmx/GetTagManagers',
         {},
         callback);
     return req.then(
         (result) => {
+            let knownMgrs = new Map(this._tagManagersByMAC);
             let tagManagers = [];
             result = result.filter(u.createFilter(query));
             for (let mgrData of result) {
-                let tagManager = new WirelessTagManager(this, mgrData);
+                let tagManager = knownMgrs.get(mgrData.mac);
+                if (tagManager) {
+                    tagManager.data = mgrData;
+                } else {
+                    tagManager = new WirelessTagManager(this, mgrData);
+                    this.emit('discover', tagManager);
+                }
                 tagManagers.push(tagManager);
-                this.emit('discover', tagManager);
             }
+            // repopulate map of tag managers from scratch unless we were
+            // asked to filter
+            if ((! query) || (Object.keys(query).length === 0)) {
+                this._tagManagersByMAC.clear();
+            }
+            tagManagers.forEach((m) => {
+                this._tagManagersByMAC.set(m.mac, m);
+            });
             if (callback) callback(null, { object: this, value: tagManagers });
             return tagManagers;
+        },
+        this.errorHandler(callback)
+    );
+};
+
+WirelessTagPlatform.prototype.findTagManager = function(mac, callback) {
+    let mgr = this.getTagManager(mac);
+    if (mgr) {
+        if (callback) callback(null, { object: this, value: mgr });
+        return Promise.resolve(mgr);
+    }
+    let ecb = (err) => { if (err) return callback(err); };
+    return this.discoverTagManagers({ mac: mac }, ecb).then((mgrs) => {
+        if (callback) callback(null, { object: this, value: mgrs[0] });
+        return mgrs[0];
+    });
+};
+
+WirelessTagPlatform.prototype.getTagManager = function(mac) {
+    return this._tagManagersByMAC.get(mac);
+};
+
+WirelessTagPlatform.prototype.discoverTags = function(query, callback) {
+
+    // we will need all matching tag manager objects anyway, so request an
+    // up-to-date cache of those upfront, possibly filtering if requested
+    query = Object.assign({}, query);   // copy so we can manipulate keys
+    let mgrFilter = u.createFilter(query.wirelessTagManager);
+    let ecb = (err) => { if (err) return callback(err); };
+    let req = this.discoverTagManagers(mgrFilter, ecb);
+    delete query.wirelessTagManager;    // ensure this doesn't interfere below 
+
+    // only then make the actual API call for discovering tags
+    req = req.then(() => {
+        return this.callAPI(
+            '/ethClient.asmx/GetTagManagerTagList',
+            {},
+            callback);
+    });
+    return req.then(
+        (result) => {
+            let filter = u.createFilter(query);
+            let tagObjs = [];
+            for (let rec of result) {
+                let mgr = this.getTagManager(rec.mac);
+
+                // skip this record if tag managers are filtered and
+                // it doesn't pass the filter
+                if (! mgrFilter(mgr || rec)) continue;
+
+                // if record passes tag manager filter, the object is required
+                if (! mgr) {
+                    let e =  new Error("Tag manager "+ mgr.mac +" not found");
+                    if (callback) callback(e);
+                    throw e;  // if no callback, or the callback didn't throw
+                }
+
+                // create and populate tag objects
+                let tagsList = rec.tags.filter(filter);
+                for (let tagData of tagsList) {
+                    let tag = new WirelessTag(mgr, tagData);
+                    // console.log(tagData);
+                    tagObjs.push(tag);
+                    mgr.emit('discover', tag);
+                }
+            }
+            if (callback) callback(null, { object: this, value: tagObjs });
+            return tagObjs;
         },
         this.errorHandler(callback)
     );

--- a/lib/tagmanager.js
+++ b/lib/tagmanager.js
@@ -46,8 +46,6 @@ const rwMgrProps = ["name"];
 function WirelessTagManager(platform, data) {
     EventEmitter.call(this);
     this.wirelessTagPlatform = platform;
-    this.wirelessTags = [];
-    this.wirelessTagMap = {};
     this.errorHandler = platform ? platform.errorHandler : u.defaultHandler;
     this.callAPI = WirelessTagPlatform.callAPI;
     u.setObjProperties(this, roMgrProps, rwMgrProps);
@@ -56,38 +54,9 @@ function WirelessTagManager(platform, data) {
 util.inherits(WirelessTagManager, EventEmitter);
 
 WirelessTagManager.prototype.discoverTags = function(query, callback) {
-
-    var req = this.callAPI(
-        '/ethClient.asmx/GetTagManagerTagList',
-        {},
-        callback);
-    return req.then(
-        (result) => {
-            result = result.filter((elem) => {
-                return elem.mac == this.mac;
-            });
-            if (result.length != 1) {
-                let e =  new Error(result.length
-                                   + " result(s) for tag manager " + this.mac);
-                if (callback) callback(e);
-                throw e;  // if no callback, or the callback didn't throw
-            }
-            let tagsList = result[0].tags.filter(u.createFilter(query));
-            this.wirelessTags = [];
-            this.wirelessTagMap = {};
-            for (let tagData of tagsList) {
-                let tag = new WirelessTag(this, tagData);
-                // console.log(tagData);
-                this.wirelessTags.push(tag);
-                this.wirelessTagMap[tag.uuid] = tag;
-                this.emit('discover', tag);
-            }
-            if (callback) callback(null,
-                                   { object: this, value: this.wirelessTags });
-            return this.wirelessTags;
-        },
-        this.errorHandler(callback)
-    );
+    query = Object.assign({ "wirelessTagManager": {} }, query);
+    query.wirelessTagManager.mac = this.mac;
+    return this.wirelessTagPlatform.discoverTags(query, callback);
 };
 
 WirelessTagManager.prototype.select = function(callback) {

--- a/lib/tagmanager.js
+++ b/lib/tagmanager.js
@@ -53,12 +53,52 @@ function WirelessTagManager(platform, data) {
 }
 util.inherits(WirelessTagManager, EventEmitter);
 
+/**
+ * Discover event. Emitted for every {@link WirelessTag} instance discovered.
+ *
+ * @event WirelessTagManager#discover
+ * @type {WirelessTag}
+ */
+/**
+ * Data event. Emitted whenever the properties data for an instance changes.
+ *
+ * @event WirelessTagManager#data
+ * @type {WirelessTagManager}
+ */
+
+/**
+ * Retrieves the tags associated with this tag managaer and available
+ * to the connected account. The list is optionally filtered depending
+ * on the supplied query parameter.
+ *
+ * @param {Object} [query] - an object with keys and values that a tag
+ *                 data object returned by the API has to meet. The
+ *                 most useful ones are likely `name` and
+ *                 `uuid`. Consult the [GetTagForSlaveId JSON API]{@link http://wirelesstag.net/media/mytaglist.com/ethClient.asmx@op=GetTagForSlaveId.html}
+ *                 for possible keys.
+ * @param {module:wirelesstags~apiCallback} [callback] - if provided,
+ *                `query` must be provided too, even if as value undefined.
+ *
+ * @fires WirelessTagManager#discover
+ * @returns {Promise} Resolves to an array of {@link WirelessTag} instances.
+ */
 WirelessTagManager.prototype.discoverTags = function(query, callback) {
     query = Object.assign({ "wirelessTagManager": {} }, query);
     query.wirelessTagManager.mac = this.mac;
     return this.wirelessTagPlatform.discoverTags(query, callback);
 };
 
+/**
+ * Selects this tag manager for subsequent API calls that expect it,
+ * if this tag manager is not already selected.
+ *
+ * Note that the library will call this automatically, and so a user
+ * will not normally need to do so.
+ *
+ * @param {module:wirelesstags~apiCallback} [callback]
+ *
+ * @returns {Promise} resolves to the tag manager instance
+ */
 WirelessTagManager.prototype.select = function(callback) {
     return this.wirelessTagPlatform.selectTagManager(this, callback);
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -84,12 +84,13 @@ TagUtils.defaultHandler = function(callback) {
 };
 
 TagUtils.createFilter = function(jsonQuery) {
-    if (! jsonQuery) {
+    if ('function' === typeof jsonQuery) return jsonQuery;
+    if ((!jsonQuery) || (Object.keys(jsonQuery).length === 0)) {
         return function(obj) {
             return true;
         };
     }
-    if ('function' === typeof jsonQuery) return jsonQuery;
+    jsonQuery = Object.assign({}, jsonQuery); // protect against side effects
     return function(obj) {
         for(let key of Object.keys(jsonQuery)) {
             if (! Object.is(obj[key], jsonQuery[key])) return false;


### PR DESCRIPTION
The API endpoints being called for the all-in-one-go discovery are really the same as for the one-tag-manager-at-a-time path. Therefore, while there is little difference if there is only a single tag manager, for those with multiple tag managers the all-in-one-go path should be better performing because each API endpoint (one for finding tag managers, one for finding tags) is only called once, and it's the code that stitches their results together.