### PR TITLE
Switches distribution used by Travis CI to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: trusty
 node_js:
     - "6"
     - "4"


### PR DESCRIPTION
The default is Ubuntu Precise, which seems to be lacking the right compiler versions for NodeJS native-compiled extensions. See [Travis CI documentation](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements)