### PR TITLE
Fixes tolerance calculation for time sincee last update

### DIFF
--- a/test/03_manager_and_tags.js
+++ b/test/03_manager_and_tags.js
@@ -406,9 +406,13 @@ describe('WirelessTag:', function() {
             // skip this if we don't have connection information
             if (credentialsMissing) return this.skip();
 
+            // Ideally we could choose a relatively tight tolerance.
+            // However, we're testing whether this library works, not
+            // the reliability of the hardware.
             function tolerance(interval) {
-                let tol = interval * 1000 * 0.15;    // 15% of interval
-                return  (tol < 15000) ? tol : 15000; // but at least 15sec
+                const minTol = 30000;                // at least 30sec
+                let tol = interval * 1000 * 0.20;    // or 20% of interval
+                return  (tol > minTol) ? tol : minTol; 
             }
 
             tags.forEach((tag) => {


### PR DESCRIPTION
A small bug held the tolerance erroneously to 15 seconds, which time since last update frequently exceeded. Fixed this, and also increased tolerance to 20% of update interval, since what we're testing is this code, not the tolerance limits of the hardware.