### PR TITLE
Changes API for connecting

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -56,6 +56,16 @@ function WirelessTagPlatform(options) {
     this._tagManagersByMAC = new Map();
     /** @member {WirelessTagPlatform~factory} */
     this.factory = options.factory || WirelessTagPlatform.factory(this);
+    /**
+     * Whether or not this object is currently in the process of connecting
+     * (i.e., signing in).
+     * @name connecting
+     * @type {boolean}
+     * @memberof WirelessTagPlatform#
+     */
+    Object.defineProperty(this, "connecting", {
+        get: function() { return this._connecting === true }
+    });
 }
 util.inherits(WirelessTagPlatform, EventEmitter);
 
@@ -76,8 +86,8 @@ util.inherits(WirelessTagPlatform, EventEmitter);
 
 /**
  * Connects to the cloud API if not connected already. Note that the
- * {@link WirelessTagPlatform#event:connect} event will not fire if
- * already connected.
+ * {@link WirelessTagPlatform#event:connect} event will fire regardless
+ * of whether the object is already connected.
  *
  * @param {Object} opts - connection parameters
  * @param {String} opts.username - the username (email) for connecting
@@ -89,23 +99,23 @@ util.inherits(WirelessTagPlatform, EventEmitter);
  */
 WirelessTagPlatform.prototype.connect = function(opts, callback) {
 
-    return this.isConnected().then(
-        (connected) => {
-            if (connected) return this;
-            return this.callAPI(
-                '/ethAccount.asmx/Signin',
-                { email: opts.username, password: opts.password },
-                callback)
-                .then(
-                    (res) => {
-                        this.emit('connect', this);
-                        if (callback) callback(null, { object: this });
-                        return this;
-                    },
-                    this.errorHandler(callback)
-                );
+    this._connecting = true;
+
+    return this.callAPI(
+        '/ethAccount.asmx/Signin',
+        { email: opts.username, password: opts.password },
+        callback
+    ).then(
+        (res) => {
+            this._connecting = false;
+            this.emit('connect', this);
+            if (callback) callback(null, { object: this });
+            return this;
         },
-        this.errorHandler(callback)
+        (err) => {
+            this._connecting = false;
+            return this.errorHandler(callback)(err);
+        }
     );
 };
 

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -66,6 +66,12 @@ function WirelessTagPlatform(options) {
     Object.defineProperty(this, "connecting", {
         get: function() { return this._connecting === true }
     });
+    /** @member {function} - alias for {@link WirelessTagPlatform#signin} */
+    this.connect = this.signin;
+    /** @member {function} - alias for {@link WirelessTagPlatform#signoff} */
+    this.disconnect = this.signoff;
+    /** @member {function} - alias for {@link WirelessTagPlatform#isSignedIn} */
+    this.isConnected = this.isSignedIn;
 }
 util.inherits(WirelessTagPlatform, EventEmitter);
 
@@ -85,9 +91,8 @@ util.inherits(WirelessTagPlatform, EventEmitter);
  */
 
 /**
- * Connects to the cloud API if not connected already. Note that the
- * {@link WirelessTagPlatform#event:connect} event will fire regardless
- * of whether the object is already connected.
+ * Signs in to the cloud API with the given credentials. Because there is no
+ * persistent connection, here this is synonymous with connecting.
  *
  * @param {Object} opts - connection parameters
  * @param {String} opts.username - the username (email) for connecting
@@ -97,7 +102,7 @@ util.inherits(WirelessTagPlatform, EventEmitter);
  * @fires WirelessTagPlatform#connect
  * @returns {Promise} resolves to 'this' upon success
  */
-WirelessTagPlatform.prototype.connect = function(opts, callback) {
+WirelessTagPlatform.prototype.signin = function(opts, callback) {
 
     this._connecting = true;
 
@@ -120,13 +125,37 @@ WirelessTagPlatform.prototype.connect = function(opts, callback) {
 };
 
 /**
- * Tests whether this instance is connected to the cloud API.
+ * Signs off from the cloud API, which here is synonymous with disconnecting.
  *
  * @param {module:wirelesstags~apiCallback} [callback]
  *
- * @returns {Promise} resolves to true if connected, and false otherwise
+ * @fires WirelessTagPlatform#disconnect
+ * @returns {Promise} resolves to 'this' upon success
  */
-WirelessTagPlatform.prototype.isConnected = function(callback) {
+WirelessTagPlatform.prototype.signoff = function(callback) {
+
+    return this.callAPI(
+        '/ethClient.asmx/SignOut',
+        {},
+        callback
+    ).then(
+        () => {
+            this.emit('disconnect', this);
+            if (callback) callback(null, { object: this });
+            return this;
+        },
+        this.errorHandler(callback)
+    );
+};
+
+/**
+ * Tests whether this instance is signed in to the cloud API.
+ *
+ * @param {module:wirelesstags~apiCallback} [callback]
+ *
+ * @returns {Promise} resolves to true if signed in, and false otherwise
+ */
+WirelessTagPlatform.prototype.isSignedIn = function(callback) {
     return this.callAPI('/ethAccount.asmx/IsSignedIn', {}, callback).
         then((res) => {
             if (callback) callback(null, { object: this, value: res });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wirelesstags",
-  "version": "0.6.0-beta.1",
+  "version": "0.6.0-beta.2",
   "description": "Interface to the Wireless Sensor Tags platform (http://wirelesstag.net)",
   "main": "index.js",
   "scripts": {

--- a/test/02_platform.js
+++ b/test/02_platform.js
@@ -60,6 +60,34 @@ describe('WirelessTagPlatform:', function() {
         });
     });
 
+    describe('#disconnect()', function() {
+        let connectSpy = sinon.spy();
+        
+        it('should promise to disconnect platform to cloud API', function() {
+
+            platform.on('disconnect', connectSpy);
+            return expect(platform.disconnect()).to.
+                eventually.equal(platform);
+        });
+        it('should emit "disconnect" event upon connection', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            expect(connectSpy).to.have.been.calledWith(platform);
+        });
+        it('should make isConnected() promise false', function() {
+            return expect(platform.isConnected()).to.eventually.be.false;
+        });
+
+        after('reconnect', function() {
+            let connOpts = WirelessTagPlatform.loadConfig();
+             
+            if ((connOpts.username && connOpts.password) || connOpts.bearer) {
+                return platform.connect(connOpts);
+            }
+        });
+    });
+
     describe('#discoverTagManagers()', function() {
         let discoverSpy = sinon.spy();
         


### PR DESCRIPTION
* Adds property platform.connecting to help avoid race conditions between querying `platform.isConnected()` and `platform.connect()`
* Renames connect/isConnected to signin/isSignedIn. This is because there is no persistent connection, so the notion of "connecting" seems a bit inappropriate.
* Adds `platform.signoff()`.
* All name changes maintain backward compatibility through aliases. `signoff()` gets alias `disconnect()`.   