### PR TITLE
Adds findTagById() method to tag manager API

### DIFF
--- a/lib/error/InvalidOperationError.js
+++ b/lib/error/InvalidOperationError.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var util = require('util');
+var APICallError = require('./APICallError');
+
+function InvalidOperationError(msg, apiCall) {
+    APICallError.call(this, msg, apiCall);
+    this.name = this.constructor.name;
+}
+util.inherits(InvalidOperationError, APICallError);
+
+module.exports = InvalidOperationError;

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -556,6 +556,8 @@ WirelessTagPlatform.TagManagerOfflineError = require('./error/TagManagerOfflineE
 WirelessTagPlatform.TagManagerTimedOutError = require('./error/TagManagerTimedOutError');
 /** Error calling cloud API because logged in user is not authorized. */
 WirelessTagPlatform.UnauthorizedAccessError = require('./error/UnauthorizedAccessError');
+/** Error calling cloud API because the requested operation is not valid */
+WirelessTagPlatform.InvalidOperationError = require('./error/InvalidOperationError');
 /** Thrown if the attempted cloud API call is not supported for the object for which it was made. */
 WirelessTagPlatform.OperationUnsupportedError = require('./error/OperationUnsupportedError');
 /**

--- a/lib/tagmanager.js
+++ b/lib/tagmanager.js
@@ -99,3 +99,20 @@ WirelessTagManager.prototype.discoverTags = function(query, callback) {
 WirelessTagManager.prototype.select = function(callback) {
     return this.wirelessTagPlatform.selectTagManager(this, callback);
 };
+
+/**
+ * Finds the tag associated with this tag manager and identified by the
+ * given 'slaveId'.
+ *
+ * @param {number} slaveId - the sequential ID of the tag to be found
+ * @param {module:wirelesstags~apiCallback} [callback]
+ *
+ * @returns {Promise} resolves to the tag object if successful, and otherwise
+ *                    rejects with an `InvalidOperationError`
+ * @since 0.6.2
+ */
+WirelessTagManager.prototype.findTagById = function(slaveId, callback) {
+    let factory = this.wirelessTagPlatform.factory;
+    let tag = factory.createTag(this, { slaveId: slaveId });
+    return tag.update(callback);
+};

--- a/test/03_manager_and_tags.js
+++ b/test/03_manager_and_tags.js
@@ -449,7 +449,8 @@ describe('WirelessTag:', function() {
                 return (tol > minTol) ? tol : minTol;
             }
 
-            tags.forEach((tag) => {
+            let tagsToTest = tags.filter((t) => t.isPhysicalTag());
+            tagsToTest.forEach((tag) => {
                 expect(tag.lastUpdated().getTime()).
                     to.be.at.least(Date.now()
                                    - tag.updateInterval * 1000
@@ -895,7 +896,8 @@ describe('WirelessTagSensor:', function() {
 
                let toTest = sensors.filter((s) => {
                    return ['humidity','event','moisture','motion'].
-                       indexOf(s.sensorType) >= 0;
+                       indexOf(s.sensorType) >= 0
+                       && s.wirelessTag.isPhysicalTag();
                });
                // skip if there is nothing to test
                if (toTest.length === 0) this.skip();
@@ -1152,13 +1154,13 @@ describe('WirelessTagSensor:', function() {
                    let ths = mconf.thresholds;
                    let oldThs = thresholds.shift();
                    expect(sensor.reading).
-                       to.be.closeTo(degCtoF(readings.shift()), 0.1);
+                       to.be.closeTo(degCtoF(readings.shift()), 0.101);
                    expect(ths.lowValue).
-                       to.be.closeTo(degCtoF(oldThs.lowValue), 0.1);
+                       to.be.closeTo(degCtoF(oldThs.lowValue), 0.101);
                    expect(ths.highValue).
-                       to.be.closeTo(degCtoF(oldThs.highValue), 0.1);
+                       to.be.closeTo(degCtoF(oldThs.highValue), 0.101);
                    expect(ths.hysteresis).
-                       to.be.closeTo(degCtoF(oldThs.hysteresis, true), 0.1);
+                       to.be.closeTo(degCtoF(oldThs.hysteresis, true), 0.101);
                    mconf.unit = origUnits.shift();
                });
            });

--- a/test/04_write_and_update.js
+++ b/test/04_write_and_update.js
@@ -33,9 +33,10 @@ describe('Updating Tags:', function() {
                 return tagManager.discoverTags();
             }).then((tagsFound) => {
                 tags = tagsFound;
-                // find the most out of date tag
-                focusTag = tags[0];
-                tags.forEach((t) => {
+                // find the most out of date tag that is also a physical tag
+                tagsFound = tagsFound.filter((t) => t.isPhysicalTag());
+                focusTag = tagsFound[0];
+                tagsFound.forEach((t) => {
                     if (t.lastUpdated() < focusTag.lastUpdated()) focusTag = t;
                 });
             }).catch((e) => {


### PR DESCRIPTION
This is in support of retrieving tags by MAC of tag manager and slaveId of the tag.