### PR TITLE
Uses X-Set-Mac HTTP header instead of select API call

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -523,18 +523,25 @@ WirelessTagPlatform.callAPI = function(uri, reqBody, callback) {
         uri = api_base + uri;
     }
 
-    // if we got a tag manager instance, ensure it's selected, as this is
-    // unfortunately required by most API methods
-    let selectTask = tagManager ? tagManager.select() : Promise.resolve();
+    // if we got a tag manager instance and it may need to be selected,
+    // specify it in the header
+    let options;
+    if (tagManager
+        && ((!tagManager.selected)
+            || (platform && platform.eachTagManager().length > 1))) {
+        options = { headers: { 'X-Set-Mac': tagManager.mac } };
+    }
 
-    let apiCall = selectTask.then(
-        () => makeAPICall(uri, reqBody)
-    ).catch((e) => {
+    // perform the API call
+    let apiCall = makeAPICall(uri, reqBody, options).catch((e) => {
+        // if the call failed due to lack of response from a tag, try again
+        // once if we're configured to do so
         if (platform
             && platform.retryOnError()
             && (e instanceof TagDidNotRespondError)) {
-            // we retry this only once
-            return delay(WAIT_BEFORE_RETRY).then(() => makeAPICall(uri, reqBody));
+            return delay(WAIT_BEFORE_RETRY).then(
+                () => makeAPICall(uri, reqBody, options)
+            );
         }
         let handler = platform ?
             platform.errorHandler(callback) : u.defaultHandler(callback);
@@ -543,17 +550,37 @@ WirelessTagPlatform.callAPI = function(uri, reqBody, callback) {
     return apiCall;
 };
 
-function makeAPICall(uri, reqBody) {
+/**
+ * Invokes an endpoint of the Wireless Tag JSON API, and returns a promise
+ * that resolves to the result (see below).
+ *
+ * @param {string} uri - The URI of the endpoint to invoke. If defined and
+ *          non-null, overrides the `uri` property possibly given in the
+ *          `options` parameter.
+ * @param {object} reqBody - The body for the request, as a JSON object. If
+ *          defined and non-null, overrides the `body` property possibly
+ *          given in the `options` parameter.
+ * @param {object} [options] - options to be passed through to `request()`,
+ *          such as custom headers.
+ *
+ * @returns {Promise} Resolves to the value of the `d` property of the
+ *          response body from the API endpoint (or the body itself if there
+ *          is no `d` property). Rejects in case of error.
+ */
+function makeAPICall(uri, reqBody, options) {
+    let opts = {
+        method: 'POST',
+        json: true,
+        jar: true,
+        gzip: true
+    };
+    if (options) opts = Object.assign(opts, options);
+    if (uri) opts.uri = uri;
+    if (arguments.length < 3 && ! reqBody) reqBody = {};
+    if (reqBody) opts.body = reqBody;
     let apiCall = new Promise((resolve, reject) => {
-        request({
-            method: 'POST',
-            uri: uri,
-            json: true,
-            jar: true,
-            gzip: true,
-            body: reqBody || {}
-        }, function (error, response, body) {
-            error = checkAPIerror(error, response, uri, reqBody, body);
+        request(opts, function (error, response, body) {
+            error = checkAPIerror(error, response, opts.uri, opts.body, body);
             if (error) return reject(error);
             resolve(body.d === undefined ? body : body.d);
         });

--- a/lib/platform.js
+++ b/lib/platform.js
@@ -288,6 +288,26 @@ WirelessTagPlatform.prototype.getTagManager = function(mac) {
 };
 
 /**
+ * Invokes the given action on each tag manager object currently cached,
+ * and returns the results as an array. If no action is specified, return
+ * the currently cached tag manager objects.
+ *
+ * @param {function} action - the function to invoke for each tag manager object
+ * @returns {Array} the results of each invocation
+ * @since 0.6.2
+ */
+WirelessTagPlatform.prototype.eachTagManager = function(action) {
+    let retVals = [];
+    let mgrMap = this._tagManagersByMAC;
+    if (action === undefined) {
+        if (mgrMap.values) return Array.from(mgrMap.values());
+        action = (mgr) => mgr;
+    }
+    this._tagManagersByMAC.forEach((mgr) => retVals.push(action(mgr)));
+    return retVals;
+};
+
+/**
  * Retrieves the tags available to the connected account. The list is
  * optionally filtered depending on the supplied query parameter.
  *

--- a/test/02_platform.js
+++ b/test/02_platform.js
@@ -226,6 +226,28 @@ describe('WirelessTagPlatform:', function() {
         });
     });
 
+    describe('#eachTagManager()', function() {
+
+        it('with no argument, should return an array of tag managers', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            let mgrs = platform.eachTagManager();
+            expect(mgrs).to.be.an('array');
+            expect(mgrs).to.have.length.above(0);
+            mgrs.forEach((m) => expect(m).to.be.an.instanceOf(WirelessTagManager));
+        });
+        it('with fn argument, should return an array of results from fn', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            let retVals = platform.eachTagManager((m) => m.mac);
+            expect(retVals).to.be.an('array');
+            expect(retVals).to.have.length.above(0);
+            retVals.forEach((v) => expect(v).to.be.a('string'));
+        });
+    });
+
     describe('#discoverTags()', function() {
         let discoverSpy = sinon.spy();
         let mgrDiscoverHandler = (mgr) => { mgr.on('discover', discoverSpy) };


### PR DESCRIPTION
This header is undocumented in the [JSON API documentation], but is what the web-application (see under "Example code") uses. If there is only once tag manager accessible to the account, this should make no difference, but for accounts with multiple tag managers switching between them from one API call to the next should be faster, as it reduces two API calls to one.

[JSON API documentation]: http://wirelesstag.net/media/mytaglist.com/apidoc.html