### PR TITLE
Removes support for the current sensor

### DIFF
--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -108,10 +108,6 @@ const sensorPropertiesMap = {
         eventStateValues: [undefined,
                            function() { return ["Normal", "Water Detected"] }]
     },
-    'current': {
-        reading: ["ampData", xforms.noop],
-        eventState: ["ampData", function(x) { return x.eventState }]
-    },
     'battery': {
         reading: ["batteryVolt",
                   function(x) { return u.round(x, 2) }],
@@ -172,10 +168,6 @@ const sensorApiURIs = {
     },
     'water': {
     },
-    'current': {
-        arm: "/ethClient.asmx/ArmCurrentSensor",
-        disarm: "/ethClient.asmx/DisarmCurrentSensor"
-    },
     'outofrange': {
         load: "/ethClient.asmx/LoadOutOfRangeConfig",
         save: "/ethClient.asmx/SaveOutOfRangeConfig2"
@@ -209,8 +201,8 @@ const sensorApiURIs = {
  * @property {number|string|boolean} reading - The current reading of the
  *             sensor. The type of the value depends on the type of sensor.
  *             Some sensors (light, temperature, humidity, moisture, battery,
- *             signal, current) have numeric readings, some (outofrange,
- *             water) have boolean, and some (event) have string values.
+ *             signal) have numeric readings, some (outofrange, water)
+ *             have boolean, and some (event) have string values.
  *             For some sensors (currently only motion) the reading is
  *             undefined because the Wireless Tag platform does not provide
  *             access to a regularly updated value.

--- a/lib/sensorconfig.js
+++ b/lib/sensorconfig.js
@@ -176,18 +176,6 @@ const monitoringPropertiesMap = {
             undefined,
             xforms.mapObjectFunction(objectMaps.notifyMap, 'notifySettings')]
     },
-    'current': {
-        notifySettings: [
-            undefined,
-            xforms.mapObjectFunction(objectMaps.notifyMap, 'notifySettings')],
-        thresholds: [
-            undefined,
-            xforms.mapObjectFunction(objectMaps.thresholdMap, 'thresholds')],
-        samplingPeriod: ["sampling_period", xforms.noop, xforms.noop],
-        responsiveness: ["interval",
-                         xforms.mapFunction(capResponsivenessStates),
-                         xforms.revMapFunction(capResponsivenessStates)]
-    },
     'battery': {
         notifySettings: [
             undefined,
@@ -237,10 +225,6 @@ const sensorMonitorApiURIs = {
         load: "/ethClient.asmx/LoadCapSensorConfig2",
         payloadKey: "shortedEvent",
         save: "/ethClient.asmx/SaveWaterSensorConfig2"
-    },
-    'current': {
-        load: "/ethClient.asmx/LoadCurrentSensorConfig",
-        save: "/ethClient.asmx/SaveCurrentSensorConfig2"
     },
     'outofrange': {
         load: "/ethClient.asmx/LoadOutOfRangeConfig",

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -246,9 +246,18 @@ WirelessTag.prototype.hasHumiditySensor = function() {
 WirelessTag.prototype.hasTempSensor = function() {
     return !(this.tagType === 82 || this.tagType === 92);
 };
-/** Whether the tag has a current sensor. */
+/**
+ * Whether the tag has a current sensor.
+ *
+ * Note that the current sensor tag has been discontinued, so this will now
+ * always return false.
+ */
 WirelessTag.prototype.hasCurrentSensor = function() {
-    return this.tagType === 42;
+    // This used to be tagType 42, but apparently current sensor has been
+    // discontinued. Unfortunately tagType 42 is now used for a different
+    // type of sensor, namely Outdoor Temperature & Humidity, so we have
+    // currently no way of detecting whether a current sensor is back or not.
+    return false;
 };
 /**
  * Whether the tag tracks and reports out of range status. (All non-virtual

--- a/test/03_manager_and_tags.js
+++ b/test/03_manager_and_tags.js
@@ -937,13 +937,13 @@ describe('WirelessTagSensor:', function() {
                });
            });
 
-        it('should have \'thresholds\' for temp, light, humidity, moisture, current',
+        it('should have \'thresholds\' for temp, light, humidity, moisture',
            function() {
                // skip this if we don't have connection information
                if (credentialsMissing) return this.skip();
 
                let toTest = sensors.filter((s) => {
-                   return ['current','humidity','light','moisture','temp'].
+                   return ['humidity','light','moisture','temp'].
                        indexOf(s.sensorType) >= 0;
                });
                // skip if there is nothing to test


### PR DESCRIPTION
The current sensor tag type has apparently been discontinued by the Wireless Sensor Tags vendor, if they were ever available for purchase.

Closes #40.