### PR TITLE
Recognition and handling of Outdoor series tag models

### DIFF
--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -89,7 +89,31 @@ const sensorPropertiesMap = {
                            u.round(x, 2) : u.round(x, 1);
                   }],
         eventState: ["tempEventState", xforms.mapFunction(tempEventStates)],
-        eventStateValues: [undefined, xforms.valuesInMapFunction(tempEventStates)]
+        eventStateValues: [undefined, xforms.valuesInMapFunction(tempEventStates)],
+        probeType: [
+            "ds18",
+            function(x) {
+                if (x) return "DS18B20";
+                let tag = this.wirelessTag;
+                // ds18 is false means external probe is
+                // (i) a thermocouple, not a DS18B20
+                if (tag.hasSecondaryTempSensor()) return "Thermocouple";
+                // (ii) required but not connected
+                if (tag.isExternalTempProbe()) return undefined;
+                // (iii) optional but not connected, or not supported
+                return "Internal";
+            }],
+        probeDisconnected: [
+            "ds18",
+            function(x) {
+                if (x) return false;
+                // ds18 is false means external probe is
+                // (i) required but not connected,
+                if (this.wirelessTag.isExternalTempProbe()) return true;
+                // (ii) supported but not detectable as connected or not, or
+                // (iii) not supported,
+                return undefined;
+            }]
     },
     'secondarytemp': {
         reading: ["cap",   // yes, really
@@ -100,24 +124,32 @@ const sensorPropertiesMap = {
                        }
                        return this.wirelessTag.canHighPrecTemp() ?
                            u.round(x, 2) : u.round(x, 1);
-                  }]
+                  }],
+        probeType: [undefined, function() { return "Internal" }]
     },
     'humidity': {
         reading: ["cap", xforms.noop],
         eventState: ["capEventState", xforms.mapFunction(humidityEventStates)],
-        eventStateValues: [undefined, xforms.valuesInMapFunction(humidityEventStates)]
+        eventStateValues: [undefined, xforms.valuesInMapFunction(humidityEventStates)],
+        probeType: [undefined, function() { return "Internal" }]
     },
     'moisture': {
         reading: ["cap", xforms.noop],
         eventState: ["capEventState", xforms.mapFunction(moistureEventStates)],
-        eventStateValues: [undefined, xforms.valuesInMapFunction(moistureEventStates)]
+        eventStateValues: [undefined, xforms.valuesInMapFunction(moistureEventStates)],
+        probeType: [
+            undefined,
+            function() {
+                return this.wirelessTag.isOutdoorTag() ? "BLDXXXX" : "Internal";
+            }]
     },
     'water': {
         reading: ["shorted", xforms.noop],
         eventState: ["shorted",
                      function(x) { return x ? "Water Detected" : "Normal" }],
         eventStateValues: [undefined,
-                           function() { return ["Normal", "Water Detected"] }]
+                           function() { return ["Normal", "Water Detected"] }],
+        probeType: [undefined, function() { return "Internal" }]
     },
     'battery': {
         reading: ["batteryVolt",
@@ -227,6 +259,17 @@ const sensorApiURIs = {
  *             not. (Nor does the motion sensor, because it would be redundant
  *             with the event sensor.)
  * @property {string[]} eventStateValues - the possible values for `eventState`
+ * @property {string} probeType - only for temperature (`temp`,
+ *             `secondarytemp`), `humidity`, and `moisture` sensors, the type
+ *             of measurement probe or mechanism. Typically `Internal`, but
+ *             can be `DS18B20` and `Thermocouple` for temperature, and
+ *             `BLDXXXX` for moisture/humidity sensors, respectively, of tags
+ *             capable of using an alternative probe.
+ * @property {boolean} probeDisconnected - `true` if an external probe is
+ *             detected as disconnected, `false` if it is detected as connected,
+ *             and `undefined` (or not present as a property) if the
+ *             connection status can't be detected (or if the tag doesn't
+ *             support external probes).
  * @property {number} gracePeriod - only for `outofrange` sensors, the grace
  *             period in seconds after which a tag will go into `Out Of Range`
  *             state after losing contact with the tag manager.

--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -85,7 +85,7 @@ const sensorPropertiesMap = {
                        if (mconf && mconf.unit === "degF") {
                            x = xforms.degCtoF(x);
                        }
-                       return this.wirelessTag.isHTU() ?
+                       return this.wirelessTag.canHighPrecTemp() ?
                            u.round(x, 2) : u.round(x, 1);
                   }],
         eventState: ["tempEventState", xforms.mapFunction(tempEventStates)],

--- a/lib/sensor.js
+++ b/lib/sensor.js
@@ -91,6 +91,17 @@ const sensorPropertiesMap = {
         eventState: ["tempEventState", xforms.mapFunction(tempEventStates)],
         eventStateValues: [undefined, xforms.valuesInMapFunction(tempEventStates)]
     },
+    'secondarytemp': {
+        reading: ["cap",   // yes, really
+                   function(x) {
+                       let mconf = this.monitoringConfig();
+                       if (mconf && mconf.unit === "degF") {
+                           x = xforms.degCtoF(x);
+                       }
+                       return this.wirelessTag.canHighPrecTemp() ?
+                           u.round(x, 2) : u.round(x, 1);
+                  }]
+    },
     'humidity': {
         reading: ["cap", xforms.noop],
         eventState: ["capEventState", xforms.mapFunction(humidityEventStates)],
@@ -157,6 +168,8 @@ const sensorApiURIs = {
     'temp': {
         arm: "/ethClient.asmx/ArmTempSensor",
         disarm: "/ethClient.asmx/DisarmTempSensor"
+    },
+    'secondarytemp': {
     },
     'humidity': {
         arm: "/ethClient.asmx/ArmCapSensor",

--- a/lib/sensorconfig.js
+++ b/lib/sensorconfig.js
@@ -155,6 +155,17 @@ const monitoringPropertiesMap = {
                }],
         thresholdQuantization: ["threshold_q", xforms.noop, xforms.noop]
     },
+    'secondarytemp': {
+        unit: ["temp_unit",
+               function(x) { return x === 0 ? "degC" : "degF" },
+               function(mode) {
+                   switch (mode) {
+                       case "degC": return 0;
+                       case "degF": return 1;
+                       default: throw new RangeError("unrecognized unit '" + mode + "'");
+                   }
+               }]
+    },
     'humidity': {
         notifySettings: [
             undefined,
@@ -210,6 +221,9 @@ const sensorMonitorApiURIs = {
     'temp': {
         load: "/ethClient.asmx/LoadTempSensorConfig",
         save: "/ethClient.asmx/SaveTempSensorConfig2"
+    },
+    'secondarytemp': {
+        load: "/ethClient.asmx/LoadTempSensorConfig"
     },
     'humidity': {
         load: "/ethClient.asmx/LoadCapSensorConfig2",

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -137,6 +137,7 @@ WirelessTag.prototype.hardwareFacts = function() {
         if (cap.startsWith("can")
             || cap.startsWith("is")
             || (cap.startsWith("has") && !cap.endsWith("Sensor"))) {
+            if (cap === "isHTU") continue; // deprecated, hence skip
             let propValue = this[cap];
             if ((('function' === typeof propValue) && propValue.call(this))
                 || (('function' !== typeof propValue) && propValue)) {
@@ -335,8 +336,15 @@ WirelessTag.prototype.canHighPrecTemp = function() {
 };
 /**
  * Whether the tag's temperature sensor is high-precision (> 8-bit).
+ *
+ * @deprecated since v0.7.x, use [canHighPrecTemp()]{@link WirelessTag#canHighPrecTemp} instead
  */
 WirelessTag.prototype.isHTU = function() {
+    if (this.log) {
+        let log = this.log.warn || this.log.info;
+        log(__filename.replace(__dirname, "").substring(1)
+            + ": tag.isHTU() is deprecated, use tag.canHighPrecTemp() instead");
+    }
     return this.canHighPrecTemp();
 };
 /** Whether the tag object represents a physical rather than a virtual tag. */

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -181,8 +181,9 @@ WirelessTag.prototype.version = function() {
             case 15: return "2.2";
             case 31: return "2.3";
             case 32: return "2.4";
-            default: return "2.0";
         }
+        if (this.rev > 32) return "2.5";
+        return "2.0";
     case 3:
         return "3.0";
     case 4:
@@ -205,6 +206,7 @@ WirelessTag.prototype.version = function() {
 
 /** Whether the tag has a motion sensor. */
 WirelessTag.prototype.hasMotionSensor = function() {
+    if ((this.rev & 0x0F) === 0x0E && this.rev >= 0x4E) return false;
     return (this.tagType === 12 || this.tagType === 13 || this.tagType === 21);
 };
 /** Whether the tag has a light sensor. */
@@ -213,6 +215,7 @@ WirelessTag.prototype.hasLightSensor = function() {
 };
 /** Whether the tag has a moisture sensor. */
 WirelessTag.prototype.hasMoistureSensor = function() {
+    if (this.isOutdoorTag() && (this.rev & 0x0F) === 0x0E) return true;
     return (this.tagType === 32 || this.tagType === 33);
 };
 /** Whether the tag has a water sensor. */
@@ -240,11 +243,24 @@ WirelessTag.prototype.hasEventSensor = function() {
 };
 /** Whether the tag has a humidity sensor. */
 WirelessTag.prototype.hasHumiditySensor = function() {
-    return this.isHTU();
+    if (this.isOutdoorTag()) return false;
+    if ((this.rev & 0x0F) === 0x0D && this.rev >= 0x4D) return false;
+    return this.canHighPrecTemp();
 };
 /** Whether the tag has a temperature sensor. */
 WirelessTag.prototype.hasTempSensor = function() {
     return !(this.tagType === 82 || this.tagType === 92);
+};
+/**
+ * Whether the tag has an secondary temperature sensor available concurrent
+ * with a primary one.
+ *
+ * For tags that can measure temperature in different ways but for which one
+ * temperature sensor stands in for the other (which currently includes the
+ * GE Protimeter model of the Outdoor tags), this will return `false`.
+ */
+WirelessTag.prototype.hasSecondaryTempSensor = function() {
+    return (this.isOutdoorTag() && (this.rev & 0x0F) === 0x0F);
 };
 /**
  * Whether the tag has a current sensor.
@@ -283,6 +299,13 @@ WirelessTag.prototype.hasSignalSensor = function() {
 WirelessTag.prototype.hasAccelerometer = function() {
     return this.hasMotionSensor() && ((this.rev & 0x0F) === 0x0A);
 };
+/**
+ * Whether an external probe for measuring temperature can be connected to
+ * the tag.
+ */
+WirelessTag.prototype.canExternalTempProbe = function() {
+    return this.hasReedSensor() || this.isOutdoorTag();
+};
 /** Whether the tag's motion sensor can time out. */
 WirelessTag.prototype.canMotionTimeout = function() {
     return this.hasMotionSensor()
@@ -301,13 +324,20 @@ WirelessTag.prototype.canPlayback = function() {
     return (this.tagType === 21);
 };
 /** Whether the tag's temperature sensor is high-precision (> 8-bit). */
-WirelessTag.prototype.isHTU = function() {
+WirelessTag.prototype.canHighPrecTemp = function() {
     return this.tagType === 13 || this.tagType === 21 // motion && type != 12
         || this.tagType === 52                        // reed && type != 53
         || this.tagType === 26                        // ambient light
         || this.tagType === 72                        // PIR
+        || this.tagType === 42                        // outdoor tag w/ probe
         || this.isKumostat()
     ;
+};
+/**
+ * Whether the tag's temperature sensor is high-precision (> 8-bit).
+ */
+WirelessTag.prototype.isHTU = function() {
+    return this.canHighPrecTemp();
 };
 /** Whether the tag object represents a physical rather than a virtual tag. */
 WirelessTag.prototype.isPhysicalTag = function() {
@@ -315,6 +345,24 @@ WirelessTag.prototype.isPhysicalTag = function() {
               || this.isNest()
               || this.isWeMo()
               || this.isCamera());
+};
+/**
+ * Whether the tag is of the Outdoor series.
+ *
+ * Tag models of the Outdoor series use external probes for temperature
+ * and/or humidity, and feature a water and dustproof enclosure.
+ */
+WirelessTag.prototype.isOutdoorTag = function() {
+    return this.tagType === 42;
+};
+/**
+ * Whether the tag is (i.e., requires) an external temperature probe.
+ *
+ * In contrast to [canExternalTempProbe]{@link WirelessTag#canExternalTempProbe},
+ * if `true` there is no alternative for measuring temperature.
+ */
+WirelessTag.prototype.isExternalTempProbe = function() {
+    return this.isOutdoorTag() && ((this.rev & 0x0F) === 0x0D);
 };
 /** Whether the tag object represents a linked thermostat. */
 WirelessTag.prototype.isKumostat = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wirelesstags",
-  "version": "0.7.0-beta.5",
+  "version": "0.7.0-beta.6",
   "description": "Interface to the Wireless Sensor Tags platform (http://wirelesstag.net)",
   "main": "index.js",
   "scripts": {

--- a/test/03_manager_and_tags.js
+++ b/test/03_manager_and_tags.js
@@ -849,6 +849,124 @@ describe('WirelessTagSensor:', function() {
         });
     });
 
+    describe('#probeType', function() {
+        let toTest;
+
+        it('should be a string for temperature, humidity, and moisture sensors',
+           function() {
+               // skip this if we don't have connection information
+               if (credentialsMissing) return this.skip();
+
+               toTest = sensors.filter((s) => {
+                   return ['temp','secondarytemp','humidity','moisture'].
+                        indexOf(s.sensorType) >= 0;
+               });
+               // skip if there is nothing to test
+               if (toTest.length === 0) this.skip();
+
+               toTest.map((sensor) => {
+                   return sensor.probeType;
+               }).forEach((value) => {
+                   return expect(value).to.be.a('string');
+               });
+           });
+        it('should be read-only for these', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+            // skip if there is nothing to test
+            if (toTest.length === 0) this.skip();
+
+            return expect(() => {
+                toTest[0].probeType = "xzy";
+            }).to.throw(TypeError);
+        });
+        it('should be \'Internal\' if alternative probe unsupported', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            toTest = toTest.filter((s) => {
+                let t = s.wirelessTag;
+                return ! (t.isOutdoorTag() || t.canExternalTempProbe());
+            });
+            // skip if there is nothing to test
+            if (toTest.length === 0) this.skip();
+
+            toTest.map((sensor) => {
+                return sensor.probeType;
+            }).forEach((value) => {
+                return expect(value).to.equal('Internal');
+            });
+        });
+        it('should be undefined for other sensors', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            toTest = sensors.filter((s) => {
+                return ['temp','secondarytemp','humidity','moisture'].
+                    indexOf(s.sensorType) < 0;
+            });
+            // skip if there is nothing to test
+            if (toTest.length === 0) this.skip();
+
+            toTest.map((sensor) => {
+                return sensor.probeType;
+            }).forEach((value) => {
+                return expect(value).to.be.undefined;
+            });
+        });
+    });
+
+    describe('#probeDisconnected', function() {
+        let toTest;
+
+        it('should be a boolean or undefined',
+           function() {
+               // skip this if we don't have connection information
+               if (credentialsMissing) return this.skip();
+
+               // skip if there is nothing to test
+               if (sensors.length === 0) this.skip();
+
+               sensors.map((sensor) => {
+                   return sensor.probeDisconnected;
+               }).forEach((value) => {
+                   return expect(value).to.be.oneOf([true, false, undefined]);
+               });
+           });
+        it('should be defined if connection detection is possible', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            toTest = sensors.filter((s) => {
+                return s.wirelessTag.isExternalTempProbe();
+            });
+            // skip if there is nothing to test
+            if (toTest.length === 0) this.skip();
+
+            toTest.map((sensor) => {
+                return sensor.probeDisconnected;
+            }).forEach((value) => {
+                return expect(value).to.not.be.undefined;
+            });
+        });
+        it('should be undefined otherwise', function() {
+            // skip this if we don't have connection information
+            if (credentialsMissing) return this.skip();
+
+            toTest = sensors.filter((s) => {
+                return ! s.wirelessTag.isExternalTempProbe();
+            });
+            // skip if there is nothing to test
+            if (toTest.length === 0) this.skip();
+
+            toTest.map((sensor) => {
+                return sensor.probeDisconnected;
+            }).forEach((value) => {
+                return expect(value).to.be.undefined;
+            });
+        });
+    });
+
     describe('#isArmed()', function() {
         it('should be a boolean except for motion and signal sensors',
            function() {

--- a/test/03_manager_and_tags.js
+++ b/test/03_manager_and_tags.js
@@ -711,7 +711,7 @@ describe('WirelessTagSensor:', function() {
                         if (tag.canMotionTimeout()) key += "-hmc";
                         break;
                     case 'temp':
-                        if (tag.isHTU()) key += '-htu';
+                        if (tag.canHighPrecTemp()) key += '-htu';
                         break;
                     }
                     if (!sensorTypeMap[key]) {


### PR DESCRIPTION
Includes new and updated API methods for querying a tag's capabilities.

Also introduces a "secondary" temperature sensor (`tag.hasSecondaryTempSensor()`, `tag.secondarytempSensor`) for those tags that can use _and_ make available the readings from more than one temperature sensor. Currently _only_ the "Thermocouple" model in the Outdoor series does this: the one treated primary is the external probe, and the secondary is the on-board chip. Note that although in theory the "GE Protimeter" model in the Outdoor series _also_ measures temperature both from an (optional) external DS18B20 probe and with an on-board chip, only one reading is available (the probe if activated, and the internal on-board chip otherwise).

Temperature, moisture, and humidity sensors now have a (readonly) `probeType` property. For temperature sensors, it will give `DS18B20` or `Thermocouple` or `Internal`; for moisture sensors `BLDXXXX` or 'Internal`; and `Internal` if an external probe is unsupported by the tag for the respective sensor. Also, he `probeDisconnected` property will be present and have a boolean value for sensors for which an external probe is supported and for which its connection status can be detected. (The latter is currently true only for the "Basic" model in the Outdoor series.) 

Finally, this also deprecates `tag.isHTU()` from the API. The name of this method was originally borrowed from the Wireless Sensor Tags Web SDK code, where the meaning was never made explicit. It was used both for querying precision of temperature reading _and_ having a humidity sensor. Until the arrival of the Outdoor tag models, these used to be synonymous (tags with 8bit precision temperature did not have a humidity sensor). Now, however, the Outdoor tag models all support high-precision temperature reading (even if less than 13bit), yet only one of them can also measure humidity/moisture. We have been using (and documenting) `tag.isHTU()` in the semantics of having high-precision temperature, whereas in the vendor's Web SDK it is now resigned to querying for presence of a humidity sensor. To fully disambiguate, we are now deprecating `tag.isHTU()`; it is for now an alias for the preferable `tag.canHighPrecTemp()`, and will be removed from the API in a later version.

See #44 for further context and considerations that formed the basis for this implementation. The original issue report is #36.