### PR TITLE
Moves sensor object caching to tag.initializeSensor()

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -425,18 +425,17 @@ WirelessTag.prototype.discoverSensors = function() {
 };
 
 /**
- * Obtains the [sensor object]{@link WirelessTagSensor} of the given type
- * for this tag. If the sensor object hasn't been created yet for this tag,
- * creates and initializes it.
+ * Obtains, and if necessary initializes the [sensor object]{@link WirelessTagSensor}
+ * of the given type for this tag.
  *
- * Note that before completion of initialization, the sensor's configuration
- * will not be loaded, and hence actions depending on it will not work
- * correctly. This includes, for example, reading the temperature in the
- * configured unit (°C/°F), because the unit is part of the sensor
- * configuration.
+ * Upon completion of initialization, the sensor object created in this way
+ * will subsequently be available (cached) as property `tag.zzzzSensor`, where
+ * `zzzz` is the type of the sensor. An already cached sensor object will not
+ * be initialized again.
  *
- * Emits a `discover` event for a newly created sensor object once it
- * completes initialization.
+ * For a newly created sensor object, emits a `discover` event once it
+ * completes initialization. No event will be fired for previously cached
+ * objects.
  *
  * @param {string} sensorType - the type of the sensor for which to initialize
  *           the sensor object
@@ -447,42 +446,46 @@ WirelessTag.prototype.initializeSensor = function(sensorType) {
     let sensorProp = sensorType + 'Sensor';
     if (this[sensorProp]) return Promise.resolve(this[sensorProp]);
     let sensor = this.createSensor(sensorType);
+
+    function cacheAndNotify(tag, s, propName) {
+        Object.defineProperty(tag, propName, {
+            enumerable: true, value: s
+        });
+        tag.emit('discover', s);
+    }
+
     // asynchronously populate the sensor's monitoring config, and issue
     // the 'discover' event only when that completes (successfully or not)
     return sensor.monitoringConfig().update().then(
         () => {
-            this.emit('discover', sensor);
+            cacheAndNotify(this, sensor, sensorProp);
             return sensor;
         },
         (error) => {
-            this.emit('discover', sensor);
+            cacheAndNotify(this, sensor, sensorProp);
             this.errorHandler()(error);
         }
     );
 };
 
 /**
- * Creates (and subsequently caches) a [sensor object]{@link WirelessTagSensor}
- * for the given type of sensor. A sensor object created in this way will
- * subsequently be available as property `tag.zzzzSensor`, where `zzzz` is the
- * type of the sensor.
+ * Creates a [sensor object]{@link WirelessTagSensor} for the given type of
+ * sensor.
  *
  * Note that no further initialization involving the cloud API is performed,
  * and so this method behaves mostly as a factory. Specifically this means
  * that the returned sensor object will not have its sensor configuration data
- * loaded.
+ * loaded (see [MonitoringConfig.update()]{@link MonitoringConfig#update}).
  *
+ * @param {string} sensorType = the type of sensor object to be created
  * @returns {WirelessTagSensor}
+ * @throws {Error} if the tag does not support the requested type of sensor
  */
 WirelessTag.prototype.createSensor = function(sensorType) {
     if (this.sensorCapabilities().indexOf(sensorType) < 0) {
         throw Error(`tag ${this.name} does not support ${sensorType} sensor`);
     }
-    let sensor = new WirelessTagSensor(this, sensorType);
-    Object.defineProperty(this, sensorType + 'Sensor', {
-        enumerable: true, value: sensor
-    });
-    return sensor;
+    return new WirelessTagSensor(this, sensorType);
 };
 
 /**


### PR DESCRIPTION
This change doesn't change any API signatures, but it does change side effects. Specifically, previously `tag.createSensor()` cached newly created sensor objects under their dedicated property. Now this happens in `tag.initializeSensor()`, and only once a sensor has finished initialization (loading its monitoring config).

Fixes #48, and hence despite the subtle behavior change this is considered in the realm of fixing a bug.