### PR TITLE
Fixes issue with concurrent tag.initializeSensor() invocations

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -447,19 +447,25 @@ WirelessTag.prototype.initializeSensor = function(sensorType) {
     if (this[sensorProp]) return Promise.resolve(this[sensorProp]);
     let sensor = this.createSensor(sensorType);
 
+    /* eslint-disable no-prototype-builtins */
     function cacheAndNotify(tag, s, propName) {
-        Object.defineProperty(tag, propName, {
-            enumerable: true, value: s
-        });
-        tag.emit('discover', s);
+        if (! tag.hasOwnProperty(propName)) {
+            Object.defineProperty(tag, propName, {
+                enumerable: true, value: s
+            });
+        }
+        tag.emit('discover', tag[propName]);
     }
+    /* eslint-enable no-prototype-builtins */
 
     // asynchronously populate the sensor's monitoring config, and issue
     // the 'discover' event only when that completes (successfully or not)
     return sensor.monitoringConfig().update().then(
         () => {
             cacheAndNotify(this, sensor, sensorProp);
-            return sensor;
+            // make sure that in the case of concurrent threads getting here
+            // we consolidate on the value that got first set for the property
+            return this[sensorProp];
         },
         (error) => {
             cacheAndNotify(this, sensor, sensorProp);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wirelesstags",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Interface to the Wireless Sensor Tags platform (http://wirelesstag.net)",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This should have been part of #49 to fix #48. Unfortunately, the remaining race condition issue only surfaced in testing the Node-RED package.